### PR TITLE
Update pubSubTest.ino

### DIFF
--- a/arduino-esp32/AWS_IOT/examples/pubSubTest/pubSubTest.ino
+++ b/arduino-esp32/AWS_IOT/examples/pubSubTest/pubSubTest.ino
@@ -28,18 +28,19 @@ void setup() {
     Serial.begin(115200);
     delay(2000);
 
-    while (status != WL_CONNECTED)
+    Serial.print("Attempting to connect to SSID: ");
+    Serial.println(WIFI_SSID);
+    
+    // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
+    WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
+    
+    while(WiFi.status() != WL_CONNECTED)
     {
-        Serial.print("Attempting to connect to SSID: ");
-        Serial.println(WIFI_SSID);
-        // Connect to WPA/WPA2 network. Change this line if using open or WEP network:
-        status = WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
-
-        // wait 5 seconds for connection:
-        delay(5000);
+        Serial.print(".");
+        delay(500);
     }
 
-    Serial.println("Connected to wifi");
+    Serial.println("connected.");
 
     if(hornbill.connect(HOST_ADDRESS,CLIENT_ID)== 0)
     {


### PR DESCRIPTION
Prior to this change, certain network settings would yield `aws_iot: failed! mbedtls_net_connect returned -0x52` most of the time (though would occasionally work). -0x52 indicates a DNS problem. I honestly have no idea why that would be related to trying to execute `WiFi.begin(...)` more than once.

However, this change resolves the error for me.